### PR TITLE
Fix agpypline version for gdal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-agpypeline
+agpypeline==0.0.50


### PR DESCRIPTION
Fixed agpypline version due to gdal update that is no longer compatible with Ubuntu 20.04